### PR TITLE
feat(dog-fetcher-rust): stream to blobstore

### DIFF
--- a/rust/dog-fetcher/Cargo.lock
+++ b/rust/dog-fetcher/Cargo.lock
@@ -90,12 +90,10 @@ name = "dog-fetcher"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "bytes",
  "serde",
  "serde_json",
  "url",
  "wasmcloud-component",
- "wit-bindgen 0.34.0",
 ]
 
 [[package]]
@@ -684,17 +682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88b0814c9a2b323a9b46c687e726996c255ac8b64aa237dd11c81ed4854760"
 dependencies = [
  "leb128",
- "wasmparser 0.217.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.219.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29cbbd772edcb8e7d524a82ee8cef8dd046fc14033796a754c3ad246d019fa54"
-dependencies = [
- "leb128",
- "wasmparser 0.219.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -709,24 +697,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.217.0",
- "wasmparser 0.217.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.219.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af5a8e37a5e996861e1813f8de30911c47609c9ff51a7284f7dbd754dc3a9f3"
-dependencies = [
- "anyhow",
- "indexmap",
- "serde",
- "serde_derive",
- "serde_json",
- "spdx",
- "wasm-encoder 0.219.1",
- "wasmparser 0.219.1",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -742,7 +714,7 @@ dependencies = [
  "tokio",
  "uuid",
  "wasi",
- "wit-bindgen 0.32.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -750,19 +722,6 @@ name = "wasmparser"
 version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca917a21307d3adf2b9857b94dd05ebf8496bdcff4437a9b9fb3899d3e6c74e7"
-dependencies = [
- "ahash",
- "bitflags",
- "hashbrown 0.14.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.219.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c771866898879073c53b565a6c7b49953795159836714ac56a5befb581227c5"
 dependencies = [
  "ahash",
  "bitflags",
@@ -842,17 +801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eb9327b2afd6af02ab39f8fbde6bfc7d369d14bc8c8688311d3defcda3952bd"
 dependencies = [
  "wit-bindgen-rt 0.32.0",
- "wit-bindgen-rust-macro 0.32.0",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e11ad55616555605a60a8b2d1d89e006c2076f46c465c892cc2c153b20d4b30"
-dependencies = [
- "wit-bindgen-rt 0.34.0",
- "wit-bindgen-rust-macro 0.34.0",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
@@ -863,18 +812,7 @@ checksum = "fc9cfd3f1b4e29e9a90fe04157764f24ae396cfb8530dae5753de140e73f9e56"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser 0.217.0",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163cee59d3d5ceec0b256735f3ab0dccac434afb0ec38c406276de9c5a11e906"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser 0.219.1",
+ "wit-parser",
 ]
 
 [[package]]
@@ -896,15 +834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744845cde309b8fa32408d6fb67456449278c66ea4dcd96de29797b302721f02"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "wit-bindgen-rust"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,25 +844,9 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn",
- "wasm-metadata 0.217.0",
- "wit-bindgen-core 0.32.0",
- "wit-component 0.217.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6919521fc7807f927a739181db93100ca7ed03c29509b84d5f96b27b2e49a9a"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata 0.219.1",
- "wit-bindgen-core 0.34.0",
- "wit-component 0.219.1",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
 ]
 
 [[package]]
@@ -947,23 +860,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-core 0.32.0",
- "wit-bindgen-rust 0.32.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c967731fc5d50244d7241ecfc9302a8929db508eea3c601fbc5371b196ba38a5"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core 0.34.0",
- "wit-bindgen-rust 0.34.0",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
 ]
 
 [[package]]
@@ -979,29 +877,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.217.0",
- "wasm-metadata 0.217.0",
- "wasmparser 0.217.0",
- "wit-parser 0.217.0",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.219.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1673163c0cb14a6a19ddbf44dd4efe6f015ec1ebb8156710ac32501f19fba2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.219.1",
- "wasm-metadata 0.219.1",
- "wasmparser 0.219.1",
- "wit-parser 0.219.1",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
 ]
 
 [[package]]
@@ -1019,25 +898,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.217.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.219.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a86f669283257e8e424b9a4fc3518e3ade0b95deb9fbc0f93a1876be3eda598"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.219.1",
+ "wasmparser",
 ]
 
 [[package]]

--- a/rust/dog-fetcher/Cargo.toml
+++ b/rust/dog-fetcher/Cargo.toml
@@ -10,9 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0.93"
-bytes = "1.8.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 url = "2.5.3"
 wasmcloud-component = "0.2.0"
-wit-bindgen = "0.34.0"

--- a/rust/dog-fetcher/src/http.rs
+++ b/rust/dog-fetcher/src/http.rs
@@ -1,0 +1,52 @@
+use url::Url;
+use wasmcloud_component::{
+    http::ErrorCode,
+    wasi::{
+        self,
+        http::types::{Fields, Scheme},
+    },
+};
+
+use crate::internal_error;
+
+/// Helper function to make an outgoing HTTP request and return the incoming body from the response
+pub(crate) fn request(url: &str) -> Result<wasi::http::types::IncomingBody, ErrorCode> {
+    let req = wasi::http::outgoing_handler::OutgoingRequest::new(Fields::new());
+    let url = Url::parse(url).map_err(|_| internal_error("failed to parse URL".to_string()))?;
+
+    if url.scheme() == "https" {
+        req.set_scheme(Some(&Scheme::Https))
+            .map_err(|_| internal_error("failed to set HTTPS scheme".to_string()))?;
+    } else if url.scheme() == "http" {
+        req.set_scheme(Some(&Scheme::Http))
+            .map_err(|_| internal_error("failed to set HTTP scheme".to_string()))?;
+    } else {
+        req.set_scheme(Some(&Scheme::Other(url.scheme().to_string())))
+            .map_err(|_| internal_error("failed to set custom scheme".to_string()))?;
+    }
+
+    req.set_authority(Some(url.authority()))
+        .map_err(|_| internal_error("failed to set URL authority".to_string()))?;
+
+    req.set_path_with_query(Some(url.path()))
+        .map_err(|_| internal_error("failed to set URL path".to_string()))?;
+
+    match wasi::http::outgoing_handler::handle(req, None) {
+        Ok(resp) => {
+            resp.subscribe().block();
+            let response = resp
+                .get()
+                .ok_or(())
+                .map_err(|_| internal_error("HTTP request response missing".to_string()))?
+                .map_err(|_| {
+                    internal_error("HTTP request response requested more than once".to_string())
+                })?
+                .map_err(|_| internal_error("HTTP request failed".to_string()))?;
+
+            response
+                .consume()
+                .map_err(|_| internal_error("failed to consume response".to_string()))
+        }
+        Err(e) => Err(e),
+    }
+}

--- a/rust/dog-fetcher/src/objstore.rs
+++ b/rust/dog-fetcher/src/objstore.rs
@@ -1,65 +1,55 @@
 //! Object storage related functionality and helper methods
 
-use anyhow::{anyhow, bail, Result};
-use bytes::Bytes;
+use wasmcloud_component::trace;
+use wasmcloud_component::wasi::blobstore::blobstore::{
+    container_exists, create_container, get_container,
+};
+use wasmcloud_component::wasi::blobstore::container::Container;
+use wasmcloud_component::wasi::blobstore::types::OutgoingValue;
+use wasmcloud_component::wasi::http::outgoing_handler::ErrorCode;
+use wasmcloud_component::wasi::http::types::IncomingBody;
+use wasmcloud_component::wasi::io::streams::StreamError;
 
-use crate::bindings::wasi::blobstore::blobstore::{container_exists, create_container, get_container};
-use crate::bindings::wasi::blobstore::container::Container;
-
-use crate::bindings::wasi::blobstore::types::{IncomingValue, OutgoingValue};
-
-/// Maximum bytes to read at a time from the incoming request body
-/// this value is chosen somewhat arbitrarily, and is not a limit for bytes read,
-/// but is instead the amount of bytes to be read *at once*
-const MAX_READ_BYTES: u32 = 2048;
-
-/// Maximum bytes to write at a time, due to the limitations on wasi-io's blocking_write_and_flush()
-const MAX_WRITE_BYTES: usize = 4096;
+use crate::internal_error;
 
 /// A helper that will automatically create a container if it doesn't exist and returns an owned copy of the name for immediate use
-pub(crate) fn ensure_container(name: &String) -> Result<Container> {
-    if container_exists(name)
-        .map_err(|e| anyhow!("error checking for container: {e}"))?
-    {
-        return get_container(name).map_err(|e| anyhow!("failed to get container: {e}"));
+pub(crate) fn ensure_container(name: &String) -> Result<Container, ErrorCode> {
+    if container_exists(name).map_err(internal_error)? {
+        return get_container(name).map_err(internal_error);
     }
-    create_container(name).map_err(|e| anyhow!("failed to create container: {e}"))
+    create_container(name).map_err(internal_error)
 }
 
-/// Write a binary blob to object storage
-pub(crate) fn write_object(object_bytes: Bytes, bucket: &str, key: &String) -> Result<()> {
+/// Stream a binary blob from an HTTP [`IncomingBody`] to object storage
+pub(crate) fn write_object(
+    object_body: IncomingBody,
+    bucket: &String,
+    key: &String,
+) -> Result<(), ErrorCode> {
     let container = ensure_container(&String::from(bucket))?;
 
     let data = OutgoingValue::new_outgoing_value();
     let data_body = data
         .outgoing_value_write_body()
-        .map_err(|()| anyhow!("failed to get data output stream"))?;
-    if let Err(e) = container.write_data(key, &data) {
-        bail!("failed to write data: {e}");
-    };
-    for chunk in object_bytes.chunks(MAX_WRITE_BYTES) {
-        data_body
-            .blocking_write_and_flush(chunk)
-            .map_err(|e| anyhow!("failed to write chunk: {e}"))?;
+        .map_err(|()| internal_error("failed to get data output stream"))?;
+    container.write_data(key, &data).map_err(internal_error)?;
+    let object_stream = object_body
+        .stream()
+        .map_err(|()| internal_error("failed to stream object"))?;
+    loop {
+        match data_body.blocking_splice(&object_stream, u64::MAX) {
+            Ok(0) | Err(StreamError::Closed) => break,
+            Ok(n) => {
+                trace!("wrote {n} bytes to object storage");
+                continue;
+            }
+            Err(e) => return Err(internal_error(e)),
+        }
     }
     drop(data_body);
-    OutgoingValue::finish(data).map_err(|e| anyhow!("failed to write data: {e}"))?;
+    drop(object_stream);
+    OutgoingValue::finish(data).map_err(internal_error)?;
+    let _trailers = IncomingBody::finish(object_body);
 
     Ok(())
-}
-
-/// Read a binary blob from object storage
-pub(crate) fn read_object(bucket: &str, key: &str) -> Result<Bytes> {
-    let key = &String::from(key);
-    let container = ensure_container(&String::from(bucket))?;
-    let metadata = container
-        .object_info(key)
-        .map_err(|e| anyhow!("failed to get object metadata: {e}"))?;
-    let incoming = container
-        .get_data(key, 0, metadata.size)
-        .map_err(|e| anyhow!("failed to get data: {e}"))?;
-    let body = IncomingValue::incoming_value_consume_sync(incoming)
-        .map_err(|e| anyhow!("failed to consume incoming value: {e}"))?;
-
-    Ok(Bytes::from(body))
 }


### PR DESCRIPTION
Update the Rust example to use wasmcloud_component types and stream the HTTP body to the blobstore.